### PR TITLE
Improvising SunsetAlarmReceiver.kt

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/astronomy/infrastructure/receivers/SunsetAlarmReceiver.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/astronomy/infrastructure/receivers/SunsetAlarmReceiver.kt
@@ -52,15 +52,15 @@ class SunsetAlarmReceiver : BroadcastReceiver() {
             context.sendBroadcast(Intent(context, SunsetAlarmReceiver::class.java))
         }
 
-        // TODO: Extract this out of the receiver
-        /**
-         * Enable sunset alerts and request permissions if needed
-         */
-        fun <T> enable(
-            fragment: T,
+        fun enable(
+            fragment: Fragment,
             shouldRequestPermissions: Boolean
-        ) where T : Fragment, T : IPermissionRequester {
-            UserPreferences(fragment.requireContext()).astronomy.sendSunsetAlerts = true
+        ) {
+            val preferences = UserPreferences(fragment.requireContext())
+            preferences.astronomy.sendSunsetAlerts = true
+
+            preferences.astronomy.isSunsetAlertEnabled = true
+
             if (shouldRequestPermissions) {
                 fragment.requestScheduleExactAlarms {
                     start(fragment.requireContext())
@@ -69,6 +69,23 @@ class SunsetAlarmReceiver : BroadcastReceiver() {
             } else {
                 start(fragment.requireContext())
             }
+        }
+
+        fun disable(
+            fragment: Fragment
+        ) {
+            val preferences = UserPreferences(fragment.requireContext())
+            preferences.astronomy.sendSunsetAlerts = false
+
+            preferences.astronomy.isSunsetAlertEnabled = false
+
+            val scheduler = scheduler(fragment.requireContext())
+            scheduler.cancel()
+        }
+
+        fun isSunsetAlertEnabled(context: Context): Boolean {
+            val preferences = UserPreferences(context)
+            return preferences.astronomy.sendSunsetAlerts && preferences.astronomy.isSunsetAlertEnabled
         }
     }
 }


### PR DESCRIPTION
Description of the improvement update:

1. Added functionality to enable/disable sunset alerts:  
   - Added a new function `disable()` that disables sunset alerts.
   - Modified the existing `enable()` function to set a flag (`isSunsetAlertEnabled`) indicating that sunset alerts are enabled.

2. Added functionality to check if sunset alerts are enabled:
   - Added a new function `isSunsetAlertEnabled()` that returns `true` if sunset alerts are enabled based on the preference settings.

3. Updated the `enable()` function:
   - The `enable()` function now sets the `isSunsetAlertEnabled` flag to `true` when enabling sunset alerts.

4. Updated the `disable()` function:
   - The `disable()` function sets the `isSunsetAlertEnabled` flag to `false` when disabling sunset alerts.
   - The function also cancels any pending sunset alarms using the `scheduler.cancel()` method.

Ending of this commit message: Thank you